### PR TITLE
proposal to extend backend models for frontend interfacing

### DIFF
--- a/models/user.ts
+++ b/models/user.ts
@@ -3,14 +3,3 @@ export interface User {
   email: string;
   workspaces: string[];
 }
-
-export interface UserResponse extends Omit<User, 'workspaces'> {
-  workspaces: UserWorkspace[];
-}
-
-export interface UserWorkspace {
-  id: string;
-  workspaceName: string;
-  users: string[];
-  formCount: number;
-}

--- a/mutations/createWorkspace.ts
+++ b/mutations/createWorkspace.ts
@@ -1,8 +1,13 @@
-import { UserWorkspace } from '@/models/user';
+import { WorkspaceSnapshot } from '@/models/workspace';
 import { gql } from '@apollo/client';
 
 export interface CreateWorkspaceMutationResponse {
-  createWorkspace: UserWorkspace & { __typename?: 'Workspace' };
+  createWorkspace: Pick<
+    WorkspaceSnapshot,
+    'id' | 'formCount' | 'users' | 'workspaceName'
+  > & {
+    __typename?: 'Workspace';
+  };
 }
 
 export const CREATE_WORKSPACE_MUTATION = gql`

--- a/queries/userQuery.ts
+++ b/queries/userQuery.ts
@@ -1,8 +1,20 @@
 import { gql } from '@apollo/client';
-import { UserResponse } from '@/models/user';
+import { User } from '@/models/user';
+import { WorkspaceSnapshot } from '@/models/workspace';
+import { Overwrite } from '@/utils/types';
 
 export interface UserQueryResponse {
-  user: UserResponse & { __typename?: 'User' };
+  user: Overwrite<
+    User,
+    {
+      workspaces: Pick<
+        WorkspaceSnapshot,
+        'id' | 'formCount' | 'timestamp' | 'users' | 'workspaceName'
+      >[];
+    }
+  > & {
+    __typename?: 'User';
+  };
 }
 
 export const USER_QUERY = gql`

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -1,0 +1,1 @@
+export type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;


### PR DESCRIPTION
This reuses the backend models however does not couple the frontend ones to it directly, while still giving us some type safety.  If we need to deviate farther than this, then I say leave the backend `/models` folder out of frontend code entirely, and just duplicate the interfaces. 